### PR TITLE
Changes to offline faction time recommendations

### DIFF
--- a/master.svg
+++ b/master.svg
@@ -3580,9 +3580,11 @@
          style="line-height:5.4327774px;stroke-width:0.26458332"
          id="flowPara5442" /><flowPara
          style="line-height:5.4327774px;stroke-width:0.26458332"
-         id="flowPara5444">   1) Be Druid offline until you have 7-7.5 days druid playtime</flowPara><flowPara
+         id="flowPara5444">   1) Be Druid offline until you have 5 days Druid playtime</flowPara><flowPara
          style="line-height:5.4327774px;stroke-width:0.26458332"
-         id="flowPara5448">   2) Then be Faceless until you have 14 days</flowPara><flowPara
+         id="flowPara5448">   2) Then be Faceless until you have 10 days Faceless playtime</flowPara><flowPara
          style="line-height:5.4327774px;stroke-width:0.26458332"
-         id="flowPara5450">   3) Then be Druid</flowPara></flowRoot>  </g>
+         id="flowPara5450">   3) Then be Druid until you have 10 days Druid playtime</flowPara><flowPara 
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5452">   4) Then be Faceless</flowPara></flowRoot></g>
 </svg>


### PR DESCRIPTION
These changes would allow for an early E1425, which would be helpful, in addition, 14 days on Faceless aren't needed because you will get some time on Dragon R46-R54.