### PR TITLE
Adding A2 Plot

### DIFF
--- a/master-post-a2.svg
+++ b/master-post-a2.svg
@@ -1,0 +1,4299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="2752"
+   height="1232"
+   viewBox="0 0 728.13334 325.96667"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="master-post-a - Copy.svg"
+   inkscape:export-filename="E:\a1plot.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.82919584"
+     inkscape:cx="1514.8223"
+     inkscape:cy="719.31051"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer17"
+     showgrid="false"
+     inkscape:window-width="1680"
+     inkscape:window-height="987"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="1480,880"
+     inkscape:measure-end="160,880"
+     units="px"
+     inkscape:pagecheckerboard="false"
+     inkscape:lockguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid19308"
+       units="px"
+       spacingx="8.4666668"
+       spacingy="3.7041667" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient2379"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2377" />
+    </linearGradient>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern18869"
+       id="pattern7029"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583337,-116.41657)" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern18869"
+       id="pattern6359"
+       patternTransform="matrix(0.26458333,0,0,0.26458336,10.583319,-116.41671)" />
+    <linearGradient
+       id="linearGradient6234"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#eef39d;stop-opacity:1;"
+         offset="0"
+         id="stop6232" />
+    </linearGradient>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern18869"
+       id="pattern5932"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583333,-116.41667)" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern18869"
+       id="pattern5930"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583333,-116.41667)" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern30251"
+       id="pattern5786"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583283,-116.41668)" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern30251"
+       id="pattern7633"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,21.166698,-116.41667)" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern30251"
+       id="pattern32946"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583334,-116.41668)" />
+    <linearGradient
+       id="linearGradient20775"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#9dc5f3;stop-opacity:1;"
+         offset="0"
+         id="stop20773" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient17390">
+      <stop
+         id="stop17388"
+         offset="0"
+         style="stop-color:#9df3a7;stop-opacity:1;" />
+    </linearGradient>
+    <pattern
+       id="pattern30251"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583333,-116.41667)"
+       height="39.999987"
+       width="39.999999"
+       patternUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path30084-5"
+         style="fill:#c1c7f7;fill-opacity:1;stroke:none;stroke-width:0.49999997px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 39.999999,39.999987 V 20.000013 L 20.000001,39.999987 Z M 0,20.000013 V 39.999987 L 39.999987,0 H 19.999994 Z" />
+    </pattern>
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="39.999999"
+       height="39.999987"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583333,-116.41667)"
+       id="pattern18869">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18816"
+         style="fill:#afcdb2;fill-opacity:1;stroke:none;stroke-width:0.49999997px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 39.999999,39.999987 V 20.000013 L 20.000001,39.999987 Z M 0,20.000013 V 39.999987 L 39.999987,0 H 19.999994 Z" />
+    </pattern>
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="39.999999"
+       height="39.999987"
+       patternTransform="matrix(0.26458333,0,0,0.26458333,10.583333,-116.41667)"
+       id="pattern18869-5">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18816-2"
+         style="fill:#afcdb2;fill-opacity:1;stroke:none;stroke-width:0.49999997px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 39.999999,39.999987 V 20.000013 L 20.000001,39.999987 Z M 0,20.000013 V 39.999987 L 39.999987,0 H 19.999994 Z" />
+    </pattern>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2379"
+       id="linearGradient2381"
+       x1="372.40104"
+       y1="132.93842"
+       x2="372.66562"
+       y2="132.93842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2.2697996,0,-174.03131)" />
+  </defs>
+  <pattern
+     inkscape:collect="always"
+     xlink:href="#pattern30251"
+     id="pattern7637"
+     patternTransform="matrix(0.26458333,0,0,0.26458333,10.583333,-116.41667)" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="background"
+     style="display:inline"
+     transform="translate(0,8.4666667)"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.46177566;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6108"
+       width="728.13336"
+       height="325.96664"
+       x="5.5067062e-014"
+       y="-8.46667" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="A0 Regions"
+     style="display:none"
+     transform="translate(0,40.216667)"
+     sodipodi:insensitive="true">
+    <path
+       style="fill:#c8c8c8;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 190.49998,148.16666 V 142.875 h 10.58334 v -5.29167 h 21.16666 v 5.29167 h 10.58333 v 5.29166 z"
+       id="path32954"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g33227"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path32970"
+         d="m 317.5,84.666666 v -5.291667 h 10.58333 V 74.08333 h 10.58333 v 10.583336 z"
+         style="fill:#9df3e4;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g33231"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path32972"
+         d="m 338.66666,100.54167 h 21.16667 V 63.499997 H 349.25 v 5.291666 h -10.58334 z"
+         style="fill:#eef39d;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g33240"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path32976"
+         d="m 444.49997,21.166665 h 21.16666 V 10.583331 H 455.0833 v 5.291667 h -10.58333 z"
+         style="fill:#9df3e4;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:url(#pattern30251);fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 444.49997,21.166665 h 21.16666 V 10.583331 H 455.0833 v 5.291667 h -10.58333 z"
+         id="path33006"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g5723"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path32938"
+         d="m 42.333331,243.41666 v -26.45833 h 10.583333 v -5.29167 H 63.499998 V 206.375 h 10.583333 v -5.29167 l 148.166659,10.58334 v 31.75 z"
+         style="fill:#9df3a7;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         style="fill:url(#pattern32946);fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 42.333331,243.41665 v -26.45833 h 10.583333 v -5.29167 h 10.583334 v -5.29166 h 10.583333 v -5.29167 l 148.166659,10.58335 v 31.75 z"
+         id="path32940"
+         inkscape:connector-curvature="0" />
+      <text
+         id="text33265"
+         y="229.64993"
+         x="144.91087"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332"
+           y="229.64993"
+           x="144.91087"
+           id="tspan33263"
+           sodipodi:role="line">Dwelf</tspan></text>
+    </g>
+    <g
+       id="g5728"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <path
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0"
+         id="rect32811"
+         d="m 42.333336,243.41666 179.916654,1e-5 v -31.75 l 137.58333,-10.58334 h 105.83333 v 63.49999 H 42.333336 Z"
+         style="opacity:1;fill:#9df3a6;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text33265-3"
+         y="241.9015"
+         x="284.19763"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332"
+           y="241.9015"
+           x="284.19763"
+           id="tspan33263-7"
+           sodipodi:role="line">Elf</tspan></text>
+    </g>
+    <g
+       id="g5717"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <g
+         id="g5711">
+        <rect
+           style="opacity:1;fill:#eef39d;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect32932"
+           width="74.112343"
+           height="14.081088"
+           x="42.318832"
+           y="229.35007" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="67.367813"
+           y="239.93079"
+           id="text33265-8"><tspan
+             sodipodi:role="line"
+             id="tspan33263-8"
+             x="67.367813"
+             y="239.93079"
+             style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Titan</tspan></text>
+      </g>
+    </g>
+    <g
+       id="g33595"
+       transform="translate(-1.3266667e-5,-4.5333334e-6)">
+      <path
+         sodipodi:nodetypes="cccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path32952"
+         d="m 116.41667,211.66666 h 126.99999 v -63.49999 h -63.5 v 5.29166 H 169.33333 V 158.75 h -10.58334 v 5.29166 h -10.58333 v 5.29167 h -10.58333 v 5.29167 h -10.58334 v 5.29166 h -10.58333 v 5.29167 c 1e-5,15.875 1e-5,10.58333 1e-5,26.45833 z"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text33265-7"
+         y="177.85892"
+         x="179.58145"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.69999999;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-size:9.87777805px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="177.85892"
+           x="179.58145"
+           id="tspan33263-2"
+           sodipodi:role="line">Mercenary</tspan><tspan
+           style="font-size:7.05555534px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="187.73669"
+           x="179.58145"
+           sodipodi:role="line"
+           id="tspan4802">(BDSM)</tspan></text>
+    </g>
+    <g
+       id="g33600"
+       transform="matrix(0.91666663,0,0,1,29.986109,-4.5333334e-6)">
+      <g
+         id="g4852">
+        <rect
+           style="opacity:1;fill:#c8c8c8;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect32958"
+           width="127"
+           height="63.499996"
+           x="232.83333"
+           y="148.16667" />
+        <text
+           transform="scale(1.044466,0.95742705)"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.73857498px;line-height:0.69999999;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.27634826"
+           x="283.36743"
+           y="185.76759"
+           id="text33265-7-1"><tspan
+             sodipodi:role="line"
+             id="tspan33263-2-7"
+             x="283.36743"
+             y="185.76759"
+             style="font-size:10.31700325px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.27634826">Mercenary</tspan><tspan
+             id="tspan4802-5"
+             sodipodi:role="line"
+             x="283.36743"
+             y="196.08459"
+             style="font-size:7.36928749px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.27634826">(Moonshine)</tspan></text>
+      </g>
+    </g>
+    <g
+       id="g33590"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <rect
+         style="opacity:1;fill:#fad2d2;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5840"
+         width="42.333332"
+         height="26.458332"
+         x="232.83333"
+         y="121.70833" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path32964"
+         d="M 211.66667,137.58333 H 222.25 v 5.29167 h 10.58333 v 5.29166 h 42.33334 V 105.83333 H 264.58333 V 111.125 H 254 c 0,0 0,5.29167 0,5.29167 h -10.58333 v 5.29166 H 232.83333 V 127 H 222.25 v 5.29166 h -10.58333 z"
+         style="fill:#9df3a7;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text33265-84-8-2"
+         y="133.34827"
+         x="253.96037"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.60000002;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-size:7.05555534px;line-height:0.60000002;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="133.34827"
+           x="253.96037"
+           id="tspan33263-1-0-4"
+           sodipodi:role="line">Elf</tspan><tspan
+           id="tspan33560-5"
+           style="font-size:7.05555534px;line-height:0.60000002;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="141.81493"
+           x="253.96037"
+           sodipodi:role="line">Research</tspan></text>
+    </g>
+    <g
+       id="g33644"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <g
+         id="g33235">
+        <path
+           style="fill:#fad2d2;fill-opacity:1;stroke:#141414;stroke-width:0.50270832;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 275.16666,148.16666 V 100.54167 H 285.75 v -5.291671 h 10.58333 v -5.291667 h 10.58333 v -5.291666 h 31.75 v 15.875004 h 21.16667 c 0,0 0,47.62499 0,47.62499 z"
+           id="path32968"
+           inkscape:connector-curvature="0" />
+      </g>
+      <text
+         id="text33265-9"
+         y="114.3124"
+         x="317.44452"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.80000001;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-size:9.87777805px;line-height:0.80000001;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="114.3124"
+           x="317.44452"
+           id="tspan33263-27"
+           sodipodi:role="line">Fairy</tspan><tspan
+           id="tspan33636"
+           style="font-size:9.87777805px;line-height:0.80000001;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="125.60129"
+           x="317.44452"
+           sodipodi:role="line">Research</tspan></text>
+    </g>
+    <g
+       id="g4892"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <rect
+         y="95.25"
+         x="285.74997"
+         height="5.2916756"
+         width="10.583345"
+         id="rect32958-4"
+         style="opacity:1;fill:#d0f39d;fill-opacity:1;stroke:#141414;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g7642"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6135"
+         d="m 465.66663,137.58333 h -105.8333 v -79.375 h 10.58333 V 52.916663 H 381 v -5.291666 h 10.58333 V 42.33333 h 10.58333 v -5.291666 h 10.58333 v -5.291667 h 10.58331 v -5.291666 h 10.58333 v -5.291666 h 31.75 z"
+         style="fill:#fad2d2;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:url(#pattern7637);fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 465.66663,137.58333 h -105.8333 v -79.375 h 10.58333 V 52.916663 H 381 v -5.291666 h 10.58333 V 42.33333 h 10.58333 v -5.291666 h 10.58333 v -5.291667 h 10.58331 v -5.291666 h 10.58333 v -5.291666 h 31.75 z"
+         id="path6137"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g7650"
+       transform="translate(-116.41661,-6.3333333e-6)">
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path5556"
+         d="m 476.24999,137.58333 h 105.8333 V 35.321714 l -52.91664,10e-7 v 1.719952 l -10.58333,-10e-7 v 15.874999 h -21.16666 v 12.303286 h -21.16667 z"
+         style="fill:#9df3a7;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:url(#pattern7633);fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 476.24999,137.58333 h 105.8333 V 35.321714 l -52.91664,10e-7 v 1.719952 l -10.58333,-10e-7 v 15.874999 h -21.16666 v 12.303286 h -21.16667 z"
+         id="path7608"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccc" />
+      <text
+         id="text33265-84-8"
+         y="83.098724"
+         x="529.11115"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:1;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-size:9.87777805px;line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="83.098724"
+           x="529.11115"
+           id="tspan33263-1-0"
+           sodipodi:role="line">Dwelf</tspan><tspan
+           id="tspan33560"
+           style="font-size:9.87777805px;line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="97.209839"
+           x="529.11115"
+           sodipodi:role="line">Research</tspan></text>
+    </g>
+    <g
+       id="g7673"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <rect
+         y="137.58333"
+         x="359.83334"
+         height="63.5"
+         width="105.83333"
+         id="rect7626"
+         style="opacity:1;fill:#c1c7f7;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g5838"
+         transform="translate(-1.189576,6.313635)">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="373.90585"
+           y="170.9572"
+           id="text33265-84-7"><tspan
+             sodipodi:role="line"
+             id="tspan33263-1-9"
+             x="373.90585"
+             y="170.9572"
+             style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Research (as possible)</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="379.4278"
+           y="161.21584"
+           id="text33265-84"><tspan
+             sodipodi:role="line"
+             id="tspan33263-1"
+             x="379.4278"
+             y="161.21584"
+             style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Dwelf/Dwairy</tspan></text>
+      </g>
+    </g>
+    <path
+       style="fill:#c8c8c8;fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 84.666655,195.79166 v 5.29167 H 74.083323 v 5.29167 h 42.333327 c 0,-7.05556 0,-14.11111 0,-21.16667 H 105.83332 V 190.5 H 95.249983 v 5.29166 z"
+       id="path7675"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <g
+       id="g5804"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <rect
+         y="201.08333"
+         x="359.83331"
+         height="42.333332"
+         width="105.83333"
+         id="rect5010"
+         style="opacity:1;fill:#9df3a6;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:url(#pattern5786);fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5012"
+         width="105.83333"
+         height="42.333332"
+         x="359.83331"
+         y="201.08333" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="424.69553"
+         y="225.96381"
+         id="text33265-4"><tspan
+           sodipodi:role="line"
+           id="tspan33263-3"
+           x="424.69553"
+           y="225.96381"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Dwelf</tspan></text>
+    </g>
+    <g
+       id="g5818"
+       transform="translate(-7.9666667e-6,-4.5333334e-6)">
+      <rect
+         y="216.95833"
+         x="402.16666"
+         height="47.625"
+         width="10.583333"
+         id="rect5794"
+         style="opacity:1;fill:#fad2d2;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:url(#pattern30251);fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5806"
+         width="10.583333"
+         height="47.625"
+         x="402.16666"
+         y="216.95833" />
+      <text
+         transform="rotate(90)"
+         id="text5810"
+         y="-406.14764"
+         x="232.02769"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.07500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="-406.14764"
+           x="232.02769"
+           id="tspan5808"
+           sodipodi:role="line">Dwairy</tspan></text>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer18"
+     inkscape:label="A1 Regions"
+     style="display:none;opacity:1">
+    <path
+       sodipodi:nodetypes="ccccccccccccccccc"
+       style="fill:#eef39d;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 76.199989,244.475 v 3.70417 h -8.466666 v 3.70416 h -8.466667 v 3.70417 H 50.79999 v 3.70417 h -8.466667 v 3.70416 H 33.866657 V 266.7 H 25.39999 v 37.04167 H 84.666657 V 244.475 Z"
+       id="path18065-2"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="44.613644"
+       y="285.32141"
+       id="text33265-8-1-8"><tspan
+         sodipodi:role="line"
+         id="tspan33263-8-6-5"
+         x="44.613644"
+         y="285.32141"
+         style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Titan</tspan></text>
+    <path
+       style="opacity:1;vector-effect:none;fill:#eef39d;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 143.93332,214.84167 v 3.70416 h -8.46667 V 222.25 h -8.46666 v 3.70417 h -8.46667 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 h -8.466669 v 3.70416 h -8.466667 l 3e-6,62.97084 c 149.577783,0 299.155553,0 448.733353,0 l -3e-5,-72.35993 H 152.39999 v -16.54007 z"
+       id="rect18896"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccc" />
+    <path
+       style="opacity:1;vector-effect:none;fill:url(#pattern6359);fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 143.93333,214.84167 v 3.70417 h -8.46667 V 222.25 h -8.46667 v 3.70416 h -8.46666 v 3.70418 h -8.46667 v 3.70416 h -8.46667 v 3.70417 h -8.466669 v 3.70416 h -8.466666 v 62.97084 H 152.39999 533.4 l -10e-6,-72.35992 h -381 v -16.54008 z"
+       id="path5208"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       id="g6403"
+       transform="translate(-1.1338334e-5,3.6266666e-6)">
+      <path
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path18899"
+         d="m 152.4,242.51332 50.8,0.1096 v 5.55625 H 533.40001 V 133.35 h -203.2 l -0.14492,3.70406 h -8.32176 v 3.70417 h -8.46667 v 3.70416 H 304.8 v 3.70417 h -8.46667 v 3.70417 h -8.46667 v 3.70416 H 279.4 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 H 254 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 H 228.6 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70417 H 203.2 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 H 177.8 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 H 152.4 Z"
+         style="fill:#dbd3f9;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:url(#pattern7029);fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 152.40001,242.51342 50.8,0.1096 v 5.55625 h 330.20001 l -1e-5,-62.97094 1e-5,-48.15417 h -76.2 c 0,0 -84.80751,1e-5 -127.14493,0 h -8.32175 v 3.70417 h -8.46667 v 3.70416 h -8.46666 v 3.70417 h -8.46667 v 3.70417 h -8.46667 v 3.70416 h -8.46666 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70417 h -8.46667 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 h -8.46667 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 h -8.46667 z"
+         id="path6397"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc" />
+      <flowRoot
+         xml:space="preserve"
+         id="flowRoot5293"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"><flowRegion
+           id="flowRegion5295"><rect
+             id="rect5297"
+             width="320"
+             height="84"
+             x="1184"
+             y="756" /></flowRegion><flowPara
+           id="flowPara5299" /></flowRoot>      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.11111069px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="346.24771"
+         y="190.55888"
+         id="text5303"><tspan
+           sodipodi:role="line"
+           id="tspan5433"
+           x="346.24771"
+           y="190.55888">Undeadline</tspan><tspan
+           sodipodi:role="line"
+           id="tspan5435"
+           x="346.24771"
+           y="208.19777">Dragless</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 203.2,244.475 V 192.61666 Z"
+         id="path7031"
+         inkscape:connector-curvature="0" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="494.04202"
+         y="214.25369"
+         id="text5303-0"><tspan
+           sodipodi:role="line"
+           id="tspan4711"
+           x="494.04202"
+           y="214.25369">Elfline</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4713"
+           x="494.04202"
+           y="227.48286">Dragless</tspan></text>
+    </g>
+    <g
+       id="g6035"
+       transform="translate(-1.1338334e-5,3.6266666e-6)">
+      <path
+         style="display:inline;opacity:1;vector-effect:none;fill:#c8c8c8;fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 338.66668,133.35 v -3.70417 h 8.46666 v -3.70417 h 8.46667 v -3.70416 h 8.46667 v -3.70417 l 8.46666,-1e-5 v -3.70416 h 8.46667 v -3.70417 h 8.46667 v -3.70415 h 8.46666 v -3.70415 h 8.46667 v -3.70417 h 8.46667 v -3.704165 h 8.46666 V 92.6042 h 8.46667 v -3.704169 l 8.46667,-3e-6 v -3.704159 h 8.46666 v -3.704172 h 8.46664 v -3.704169 h 8.4667 v -3.70416 h 8.46666 v -3.70417 h 8.46664 v -3.70417 h 8.4667 v -3.70416 h 8.46666 v -3.70417 h 8.46667 v -3.704167 h 8.46667 v -3.704166 h 8.46664 v -3.704167 h 8.46669 v 78.001772 59.05236 h -76.19999 c 0,-8.89105 0,-48.15417 0,-48.15417 h -127 v -3.70417 z"
+         id="path18903"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+      <text
+         id="text33265-8-1-3-2-7"
+         y="122.04716"
+         x="390.16922"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.81944466px;line-height:0.01417323;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           sodipodi:role="line"
+           id="tspan2383"
+           x="390.16922"
+           y="122.04716">Revenant 2.0</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 457.20002,137.05416 -3e-5,-55.562497 z"
+         id="path7089"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+    </g>
+    <path
+       style="fill:#f39d9d;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 533.4,81.491668 v -33.3375 h -8.46667 v 3.704166 h -8.46666 v 3.704167 H 508 v 25.929167 c 0,0 15.49466,-0.230675 25.4,0 z"
+       id="path6037"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <text
+       id="text33265-8-1-3-2-7-9"
+       y="48.125828"
+       x="465.11899"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:0.01417323;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         id="tspan7107"
+         x="465.11899"
+         y="48.125828">Ragnarok</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 389.46666,248.17917 c 0,18.52083 0,37.04167 0,55.5625 z"
+       id="path5441"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot6974"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-1.1338334e-5,3.6266666e-6)"><flowRegion
+         id="flowRegion6976"><rect
+           id="rect6978"
+           width="320"
+           height="112"
+           x="384"
+           y="980" /></flowRegion><flowPara
+         id="flowPara6980" /></flowRoot>    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="246.66362"
+       y="273.31625"
+       id="text6984"><tspan
+         sodipodi:role="line"
+         id="tspan6982"
+         x="248.52397"
+         y="273.31625"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332">Druidline </tspan><tspan
+         sodipodi:role="line"
+         x="246.66362"
+         y="286.54541"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan6988">Dragtan</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="462.93259"
+       y="273.45663"
+       id="text6984-3"><tspan
+         sodipodi:role="line"
+         id="tspan7023"
+         x="462.93259"
+         y="273.45663">Demonline</tspan><tspan
+         sodipodi:role="line"
+         id="tspan7025"
+         x="462.93259"
+         y="286.68579">Dragtan</tspan></text>
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot7075"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-1.1338334e-5,3.6266666e-6)"><flowRegion
+         id="flowRegion7077"><rect
+           id="rect7079"
+           width="192"
+           height="112"
+           x="576"
+           y="798" /></flowRegion><flowPara
+         id="flowPara7081" /></flowRoot>    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="178.12648"
+       y="221.65112"
+       id="text7085"><tspan
+         sodipodi:role="line"
+         id="tspan7083"
+         x="178.12648"
+         y="221.65112"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332">Druidline</tspan><tspan
+         sodipodi:role="line"
+         x="178.12648"
+         y="230.47057"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan7087">Dragless</tspan></text>
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot7091"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-1.1338334e-5,3.6266666e-6)"><flowRegion
+         id="flowRegion7093"><rect
+           id="rect7095"
+           width="192"
+           height="98"
+           x="1792"
+           y="448" /></flowRegion><flowPara
+         id="flowPara7097" /></flowRoot>    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="484.45209"
+       y="141.02292"
+       id="text7101"><tspan
+         sodipodi:role="line"
+         x="484.45209"
+         y="141.02292"
+         style="stroke-width:0.26458332"
+         id="tspan7103">Thor</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 499.53332,48.154167 25.4,18.520834 z"
+       id="path7113"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 507.99998,59.266667 v 22.225 h 25.4 v -33.3375 h -8.46666 v 3.704167 h -8.46667 v 3.704167 h -8.46667 z"
+       id="path7117"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 457.19998,185.20833 v 62.97083 z"
+       id="path7121"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient2381);stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 372.53333,137.05416 c 0,-42.038572 0,0 0,0 z"
+       id="path2375"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46666622px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="291.58087"
+       y="100.79878"
+       id="text2395"><tspan
+         sodipodi:role="line"
+         id="tspan2397"
+         x="291.58087"
+         y="100.79878">Night of the</tspan><tspan
+         sodipodi:role="line"
+         id="tspan2399"
+         x="291.58087"
+         y="111.38212">Living Merc</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 321.73334,114.82916 c 50.8,22.225 33.86667,14.81667 33.86667,14.81667 -14.11111,-6.17361 -19.75556,-8.64306 -33.86667,-14.81667 z"
+       id="path2401"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g2521"
+     inkscape:label="A2 joke regions"
+     style="display:inline">
+    <g
+       id="g2461"
+       transform="translate(1.9199988e-6,2.5066665e-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2455"
+         d="m 288,924 v 14 h -32 v 14 h -32 v 14 h -32 v 14 h -32 v 14 h -32 v 14 H 96 v 140 H 2016.0001 V 896.00001 H 352.00001 v 14 h -32 v 14 z"
+         style="fill:#e8a858;fill-opacity:1;stroke:#000000;stroke-width:1.51181102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="ccccccccccccccccccccc"
+         transform="scale(0.26458333)" />
+      <text
+         id="text2459"
+         y="277.29312"
+         x="249.89648"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           sodipodi:role="line"
+           id="tspan3404"
+           x="249.89648"
+           y="277.29312">Balanced Druid</tspan><tspan
+           sodipodi:role="line"
+           id="tspan3406"
+           x="249.89648"
+           y="277.49313" /></text>
+    </g>
+    <path
+       style="fill:#f39d9d;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 101.6,237.06667 h 431.80001 l -2e-5,-188.912507 h -8.46666 v 3.704167 h -8.46667 v 3.704167 h -8.46667 v 3.704166 h -8.46666 v 3.704167 h -8.46667 v 3.704167 h -8.46667 v 3.704166 h -8.46666 v 3.704167 h -8.46667 l 1e-5,3.704168 h -8.46666 v 3.704166 l -8.23636,-0.01497 -0.23031,3.719132 h -8.46667 v 3.704172 h -8.46666 v 3.704167 h -8.46667 v 3.704166 h -8.46667 v 3.704169 h -8.46666 v 3.70416 h -8.46667 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 h -8.46667 V 133.35 h -8.46666 v 3.70416 h -8.46667 v 3.70417 h -8.46667 v 3.70417 H 304.8 v 3.70417 h -8.46666 v 3.70416 h -8.46667 V 155.575 H 279.4 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 H 254 v 3.70417 h -8.46666 v 3.70416 h -8.46667 V 177.8 H 228.6 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 H 203.2 v 3.70417 h -8.46666 v 3.70416 h -8.46667 V 200.025 H 177.8 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 H 152.4 v 3.70417 h -8.46666 v 3.70416 h -8.46667 V 222.25 H 127 v 3.70417 h -8.46666 v 3.70416 h -8.46667 v 3.70417 H 101.6 Z"
+       id="path2515"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    <text
+       id="text2519"
+       y="186.36964"
+       x="348.83102"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.27777863px;line-height:0.01417323;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         id="tspan2517"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.27777863px;line-height:0.01417323;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         y="186.36964"
+         x="348.83102"
+         sodipodi:role="line">Suicide</tspan></text>
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="ivan regions"
+     id="g6182"
+     inkscape:groupmode="layer">
+    <g
+       id="g6121">
+      <path
+         style="fill:#eef39d;fill-opacity:1;stroke:#000000;stroke-width:1.51181102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288,924 v 14 h -32 v 14 h -32 v 14 h -32 v 14 h -32 v 14 h -32 v 14 H 96 v 140 H 320 V 924 Z"
+         transform="scale(0.26458333)"
+         id="path6115"
+         inkscape:connector-curvature="0" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="43.026142"
+         y="277.6485"
+         id="text6119"><tspan
+           sodipodi:role="line"
+           id="tspan6117"
+           x="43.026142"
+           y="277.6485"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Titan</tspan></text>
+    </g>
+    <rect
+       id="rect6123"
+       y="-116.41667"
+       x="10.583333"
+       height="10.58333"
+       width="10.583333"
+       style="fill:url(#pattern18869);stroke:none" />
+    <g
+       id="g6133">
+      <path
+         sodipodi:nodetypes="ccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path6125"
+         d="m 84.666672,303.74166 h 59.266668 l 1e-5,-85.19583 h -8.46667 V 222.25 H 127 v 3.70416 h -8.46666 v 3.70417 h -8.46667 v 3.70417 H 101.6 v 3.70416 h -8.466662 v 3.70417 h -8.466666 z"
+         style="display:inline;fill:#eef39d;fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="display:inline;fill:url(#pattern18869);fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 84.666672,303.74166 h 59.266668 l 1e-5,-85.19583 h -8.46667 V 222.25 H 127 v 3.70416 h -8.46666 v 3.70417 h -8.46667 v 3.70417 H 101.6 v 3.70416 h -8.466662 v 3.70417 h -8.466666 z"
+         id="path6127"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="96.799271"
+         y="275.75784"
+         id="text6131"><tspan
+           sodipodi:role="line"
+           id="tspan6129"
+           x="96.799271"
+           y="275.75784"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Dragtit</tspan></text>
+    </g>
+    <g
+       id="g6144">
+      <path
+         style="opacity:1;vector-effect:none;fill:#eef39d;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 152.39999,231.38164 h 381 v 72.36003 h -381 z"
+         id="path6136"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path6138"
+         d="m 152.39999,231.38164 h 381 v 72.36003 h -381 z"
+         style="opacity:1;vector-effect:none;fill:url(#pattern18869);fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="325.39926"
+         y="270.15649"
+         id="text6142"><tspan
+           sodipodi:role="line"
+           id="tspan6140"
+           x="325.39926"
+           y="270.15649"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Dragtit</tspan></text>
+    </g>
+    <g
+       id="g6154">
+      <path
+         style="fill:#dbd3f9;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 152.4,231.36851 380.99999,0.002 V 137.05406 H 321.73333 v 3.70417 h -8.46667 v 3.70416 H 304.8 v 3.70417 h -8.46667 v 3.70417 h -8.46667 v 3.70416 H 279.4 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 H 254 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 H 228.6 v 3.70417 h -8.46667 v 3.70417 c 0,0 -8.46666,0 -8.46666,0 v 3.70417 H 203.2 v 3.70416 h -8.46667 c 0,0 0,3.70417 0,3.70417 h -8.46666 v 3.70417 H 177.8 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 H 152.4 Z"
+         id="path6146"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6148"
+         d="m 152.4,231.36851 380.99999,0.002 V 137.05406 H 321.73333 v 3.70417 h -8.46667 v 3.70416 H 304.8 v 3.70417 h -8.46667 v 3.70417 h -8.46667 v 3.70416 H 279.4 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 H 254 v 3.70417 h -8.46667 v 3.70417 h -8.46666 v 3.70416 H 228.6 v 3.70417 h -8.46667 v 3.70417 c 0,0 -8.46666,0 -8.46666,0 v 3.70417 H 203.2 v 3.70416 h -8.46667 c 0,0 0,3.70417 0,3.70417 h -8.46666 v 3.70417 H 177.8 v 3.70416 h -8.46667 v 3.70417 h -8.46666 v 3.70417 H 152.4 Z"
+         style="fill:url(#pattern5932);fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="320.54959"
+         y="186.9687"
+         id="text6152"><tspan
+           sodipodi:role="line"
+           id="tspan6150"
+           x="320.54959"
+           y="186.9687"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Dragface</tspan></text>
+    </g>
+    <g
+       id="g6164">
+      <path
+         style="fill:#dbd3f9;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 143.93333,303.74166 H 152.4 v -88.9 h -8.46667 z"
+         id="path6156"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6158"
+         d="M 143.93333,303.74166 H 152.4 v -88.9 h -8.46667 z"
+         style="fill:url(#pattern5930);fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:7.05555534px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="243.32709"
+         y="-146.1978"
+         id="text6162"
+         transform="rotate(90)"><tspan
+           sodipodi:role="line"
+           id="tspan6160"
+           x="243.32709"
+           y="-146.1978"
+           style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Dragface</tspan></text>
+    </g>
+    <g
+       id="g6174">
+      <path
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path6166"
+         d="M 330.20001,137.05416 V 133.35 h 8.46667 v -3.70417 h 8.46666 v -3.70417 h 8.46667 v -3.70416 h 8.46667 v -3.70417 l 8.46666,-1e-5 v -3.70416 h 8.46667 v -3.70417 h 8.46667 v -3.70415 h 8.46666 v -3.70415 h 8.46667 v -3.70417 h 8.46667 v -3.704165 h 8.46666 V 92.6042 h 8.46667 v -3.704169 l 8.46667,-3e-6 v -3.704159 h 8.46666 v -3.704172 h 8.46664 v -3.704169 h 8.4667 v -3.70416 h 8.46666 v -3.70417 h 8.46664 v -3.70417 h 8.4667 v -3.70416 h 8.46666 v -3.70417 h 8.46667 v -3.704167 h 8.46667 v -3.704166 h 8.46664 v -3.704167 h 8.46669 v 88.899962 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#c8c8c8;fill-opacity:1;stroke:#141414;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="447.92685"
+         y="108.16601"
+         id="text6172"><tspan
+           sodipodi:role="line"
+           id="tspan6168"
+           x="447.92685"
+           y="108.16601"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332">Mercenary</tspan><tspan
+           sodipodi:role="line"
+           x="447.92685"
+           y="109.55238"
+           style="font-size:9.87777805px;line-height:0.01417323;stroke-width:0.26458332"
+           id="tspan6170" /></text>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path6176"
+       d="m 465.66666,77.787496 h 67.73333 c 0,0 0,-29.633333 0,-29.633333 h -8.46666 v 3.704167 h -8.46667 v 3.704167 h -8.46667 v 3.704166 h -8.46666 v 3.704167 h -8.46667 c 0,0 0,3.704167 0,3.704167 0,0 -8.46667,0 -8.46667,0 v 3.704166 h -8.46666 v 3.704167 h -8.46667 z"
+       style="fill:#f39d9d;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:7.05555534px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="499.47614"
+       y="69.30188"
+       id="text6180"><tspan
+         sodipodi:role="line"
+         x="499.47614"
+         y="69.30188"
+         style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332"
+         id="tspan6178">Suicide</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="credits"
+     style="display:inline"
+     transform="translate(0,8.4666667)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:5.50333261px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="724.64587"
+       y="302.38535"
+       id="text4943"><tspan
+         sodipodi:role="line"
+         x="724.64587"
+         y="302.38535"
+         style="font-size:4.23333311px;line-height:5.50333261px;text-align:end;text-anchor:end;stroke-width:0.26458332"
+         id="tspan4951">art by pseu; data from RG Discord</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:2.64583325px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="690.20453"
+       y="314.07654"
+       id="text4955"><tspan
+         sodipodi:role="line"
+         id="tspan4953"
+         x="690.20453"
+         y="314.07654"
+         style="font-style:italic;stroke-width:0.26458332">v0 for 2.7.4.0</tspan></text>
+    <a
+       id="a5298"
+       xlink:href="https://github.com/nyanlathotep/rg-plot"
+       transform="translate(173.30215,3.1430596)"
+       style="fill:#0069ff;fill-opacity:1">
+      <text
+         id="text5296"
+         y="304.93225"
+         x="469.7677"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:2.64583325px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0069ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-weight:normal;fill:#0069ff;fill-opacity:1;stroke-width:0.26458332"
+           y="304.93225"
+           x="469.7677"
+           id="tspan5294"
+           sodipodi:role="line">github.com/nyanlathotep/rg-plot</tspan></text>
+    </a>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer8"
+     inkscape:label="development"
+     style="display:inline"
+     transform="translate(0,8.4666667)"
+     sodipodi:insensitive="true">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:12.32552433px;line-height:0.18717054px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#c83737;fill-opacity:1;stroke:none;stroke-width:0.66029596"
+       x="786.93286"
+       y="256.9838"
+       id="text5313"
+       transform="scale(0.82342506,1.2144396)"><tspan
+         sodipodi:role="line"
+         id="tspan5311"
+         x="786.93286"
+         y="256.9838"
+         style="fill:#c83737;stroke-width:0.66029596">DEVELOPMENT</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="grid"
+     transform="translate(0,8.4666667)"
+     sodipodi:insensitive="true"
+     style="display:inline">
+    <g
+       style="display:inline"
+       transform="translate(25.399963,28.574997)"
+       inkscape:label="Grid_Polar:X6:Y12"
+       id="g13427">
+      <g
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+         inkscape:label="MajorXGridlines"
+         id="g13167">
+        <path
+           d="M 84.666667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorXDiv1"
+           id="path13157"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 169.33333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorXDiv2"
+           id="path13159"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 254,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorXDiv3"
+           id="path13161"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 338.66667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorXDiv4"
+           id="path13163"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 423.33333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorXDiv5"
+           id="path13165"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+         inkscape:label="MajorYGridlines"
+         id="g13191">
+        <path
+           d="M 0,22.225 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv1"
+           id="path13169"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,44.45 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv2"
+           id="path13171"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,66.675 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv3"
+           id="path13173"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,88.9 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv4"
+           id="path13175"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,111.125 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv5"
+           id="path13177"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,133.35 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv6"
+           id="path13179"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,155.575 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv7"
+           id="path13181"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,177.8 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv8"
+           id="path13183"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,200.025 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv9"
+           id="path13185"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,222.25 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv10"
+           id="path13187"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,244.475 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+           inkscape:label="MajorYDiv11"
+           id="path13189"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+         inkscape:label="MinorXGridlines"
+         id="g13301">
+        <path
+           d="M 8.4666667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:1"
+           id="path13193"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 16.933333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:2"
+           id="path13195"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 25.4,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:3"
+           id="path13197"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 33.866667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:4"
+           id="path13199"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 42.333333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:5"
+           id="path13201"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 50.8,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:6"
+           id="path13203"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 59.266667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:7"
+           id="path13205"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 67.733333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:8"
+           id="path13207"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 76.2,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv0:9"
+           id="path13209"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 93.133333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:1"
+           id="path13211"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 101.6,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:2"
+           id="path13213"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 110.06667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:3"
+           id="path13215"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 118.53333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:4"
+           id="path13217"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 127,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:5"
+           id="path13219"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 135.46667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:6"
+           id="path13221"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 143.93333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:7"
+           id="path13223"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 152.4,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:8"
+           id="path13225"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 160.86667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv1:9"
+           id="path13227"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 177.8,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:1"
+           id="path13229"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 186.26667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:2"
+           id="path13231"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 194.73333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:3"
+           id="path13233"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 203.2,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:4"
+           id="path13235"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 211.66667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:5"
+           id="path13237"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 220.13333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:6"
+           id="path13239"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 228.6,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:7"
+           id="path13241"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 237.06667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:8"
+           id="path13243"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 245.53333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv2:9"
+           id="path13245"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 262.46667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:1"
+           id="path13247"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 270.93333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:2"
+           id="path13249"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 279.4,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:3"
+           id="path13251"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 287.86667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:4"
+           id="path13253"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 296.33333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:5"
+           id="path13255"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 304.8,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:6"
+           id="path13257"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 313.26667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:7"
+           id="path13259"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 321.73333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:8"
+           id="path13261"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 330.2,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv3:9"
+           id="path13263"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 347.13333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:1"
+           id="path13265"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 355.6,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:2"
+           id="path13267"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 364.06667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:3"
+           id="path13269"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 372.53333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:4"
+           id="path13271"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 381,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:5"
+           id="path13273"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 389.46667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:6"
+           id="path13275"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 397.93333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:7"
+           id="path13277"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 406.4,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:8"
+           id="path13279"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 414.86667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv4:9"
+           id="path13281"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 431.8,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:1"
+           id="path13283"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 440.26667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:2"
+           id="path13285"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 448.73333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:3"
+           id="path13287"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 457.2,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:4"
+           id="path13289"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 465.66667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:5"
+           id="path13291"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 474.13333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:6"
+           id="path13293"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 482.6,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:7"
+           id="path13295"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 491.06667,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:8"
+           id="path13297"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 499.53333,0 V 266.7"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXDiv5:9"
+           id="path13299"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+         inkscape:label="MinorYGridlines"
+         id="g13423">
+        <path
+           d="M 0,3.7041667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv0:1"
+           id="path13303"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,7.4083333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv0:2"
+           id="path13305"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,11.1125 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv0:3"
+           id="path13307"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,14.816667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv0:4"
+           id="path13309"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,18.520833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv0:5"
+           id="path13311"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,25.929167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv1:1"
+           id="path13313"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,29.633333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv1:2"
+           id="path13315"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,33.3375 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv1:3"
+           id="path13317"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,37.041667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv1:4"
+           id="path13319"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,40.745833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv1:5"
+           id="path13321"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,48.154167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv2:1"
+           id="path13323"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,51.858333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv2:2"
+           id="path13325"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,55.5625 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv2:3"
+           id="path13327"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,59.266667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv2:4"
+           id="path13329"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,62.970833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv2:5"
+           id="path13331"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,70.379167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv3:1"
+           id="path13333"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,74.083333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv3:2"
+           id="path13335"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,77.7875 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv3:3"
+           id="path13337"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,81.491667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv3:4"
+           id="path13339"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,85.195833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv3:5"
+           id="path13341"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,92.604167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv4:1"
+           id="path13343"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,96.308333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv4:2"
+           id="path13345"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,100.0125 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv4:3"
+           id="path13347"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,103.71667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv4:4"
+           id="path13349"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,107.42083 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv4:5"
+           id="path13351"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,114.82917 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv5:1"
+           id="path13353"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,118.53333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv5:2"
+           id="path13355"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,122.2375 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv5:3"
+           id="path13357"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,125.94167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv5:4"
+           id="path13359"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,129.64583 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv5:5"
+           id="path13361"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,137.05417 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv6:1"
+           id="path13363"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,140.75833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv6:2"
+           id="path13365"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,144.4625 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv6:3"
+           id="path13367"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,148.16667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv6:4"
+           id="path13369"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,151.87083 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv6:5"
+           id="path13371"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,159.27917 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv7:1"
+           id="path13373"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,162.98333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv7:2"
+           id="path13375"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,166.6875 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv7:3"
+           id="path13377"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,170.39167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv7:4"
+           id="path13379"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,174.09583 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv7:5"
+           id="path13381"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,181.50417 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv8:1"
+           id="path13383"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,185.20833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv8:2"
+           id="path13385"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,188.9125 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv8:3"
+           id="path13387"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,192.61667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv8:4"
+           id="path13389"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,196.32083 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv8:5"
+           id="path13391"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,203.72917 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv9:1"
+           id="path13393"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,207.43333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv9:2"
+           id="path13395"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,211.1375 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv9:3"
+           id="path13397"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,214.84167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv9:4"
+           id="path13399"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,218.54583 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv9:5"
+           id="path13401"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,225.95417 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv10:1"
+           id="path13403"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,229.65833 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv10:2"
+           id="path13405"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,233.3625 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv10:3"
+           id="path13407"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,237.06667 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv10:4"
+           id="path13409"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,240.77083 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv10:5"
+           id="path13411"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,248.17917 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv11:1"
+           id="path13413"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,251.88333 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv11:2"
+           id="path13415"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,255.5875 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv11:3"
+           id="path13417"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,259.29167 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv11:4"
+           id="path13419"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 0,262.99583 H 508"
+           style="vector-effect:none;fill:none;fill-opacity:1;stroke:#739dcd;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.2745098"
+           inkscape:label="MinorXYiv11:5"
+           id="path13421"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         height="266.70001"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#1c79e4;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824"
+         width="508"
+         x="0"
+         y="0"
+         inkscape:label="Border"
+         id="rect13425" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer17"
+     inkscape:label="reincarnation"
+     transform="translate(0,8.4666667)"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#f00000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 25.399953,258.2333 h 8.466667 v -3.70416 h 8.466664 v -3.70417 h 8.466658 v -3.70417 h 8.466663 v -3.70416 h 8.466664 v -3.70417 h 8.466657 v -3.70417 h 8.466666 v -3.70416 h 8.466671 v -3.70417 h 8.466637 v -3.70416 h 8.46668 v -3.70417 h 8.46666 v -3.70417 h 8.46668 v -3.70416 h 8.46667 v -3.70417 h 8.46667 l 8e-5,-4.23331 H 152.4 l -7e-5,-3.70419 h 8.46667 v -3.70417 h 8.46667 v -4.23333 h 8.46668 v -3.70417 h 8.46666 v -4.23333 h 8.46668 v -4.23333 h 8.46667 v -4.7625 h 8.46667 l 4e-5,-4.23331 h 8.46667 v -3.70417 H 228.6 c 0,-1.23956 4e-5,-4.41065 0,-3.70416 h 8.46667 V 161.925 h 8.46667 v -3.70417 H 254 v -4.23333 h 8.46667 v -3.70417 l 8.46666,-2e-5 v -4.23334 H 279.4 v -4.23333 h 8.46667 v -4.7625 h 8.46667 v -4.76248 H 304.8 v -3.70416 l 8.46669,-2e-5 v -3.70417 h 8.46666 l -10e-6,-3.70415 h 8.46667 v -4.23333 l 8.46668,-2e-5 v -4.23334 h 8.46666 v -4.7625 h 8.46667 v -4.23333 h 8.46668 l -3e-5,-4.762475 8.46668,-3.5e-5 v -3.70416 h 8.46667 V 91.5458 h 8.46666 v -3.704147 h 8.46667 v -4.233318 h 8.46667 v -4.762506 h 8.46666 v -4.233337 h 8.46667 v -5.29166 h 8.46667 v -3.70417 l 8.46666,-1e-6 V 61.9125 h 8.46667 v -4.233336 l 8.46666,-10e-7 v -4.233337 h 8.46667 v -4.762493 h 8.46667 v -5.29167 H 482.6 v -3.70417 l 8.46668,10e-7 v -3.70416 h 8.46667 v -4.233337 h 8.46666 v -4.7625 h 8.46667 v -4.233333 h 8.46666 v -4.7625 h 8.46667"
+       id="path17467"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="axes"
+     transform="translate(0,8.4666667)"
+     sodipodi:insensitive="true"
+     style="display:inline">
+    <text
+       id="text13680-1-4-1-5-1-21-0-0-8-9"
+       y="310.23495"
+       x="279.23987"
+       style="font-style:normal;font-weight:normal;font-size:4.93897438px;line-height:0.20000347px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+       xml:space="preserve"
+       transform="scale(1.0000174,0.9999826)"><tspan
+         style="font-size:5.64444447px;text-align:center;text-anchor:middle;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         y="310.23495"
+         x="279.23987"
+         id="tspan13678-7-1-1-0-7-56-7-5-7-0"
+         sodipodi:role="line">Reincarnation</tspan><tspan
+         style="font-size:5.64444447px;text-align:center;text-anchor:middle;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         y="310.43497"
+         x="279.23987"
+         sodipodi:role="line"
+         id="tspan14366-20-9-5-8-1" /></text>
+    <text
+       id="text13680-1-4-1-5-1-21-0-0-8-9-6"
+       y="11.251998"
+       x="-161.95175"
+       style="font-style:normal;font-weight:normal;font-size:4.93897438px;line-height:0.20000347px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+       xml:space="preserve"
+       transform="matrix(0,-1.0000174,0.9999826,0,0,0)"><tspan
+         style="font-size:5.64444447px;text-align:center;text-anchor:middle;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         y="11.251998"
+         x="-161.95175"
+         id="tspan13678-7-1-1-0-7-56-7-5-7-0-2"
+         sodipodi:role="line">Gems</tspan><tspan
+         id="tspan30984"
+         style="font-size:5.64444447px;text-align:center;text-anchor:middle;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         y="11.452002"
+         x="-161.95175"
+         sodipodi:role="line" /><tspan
+         style="font-size:5.64444447px;text-align:center;text-anchor:middle;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         y="11.652005"
+         x="-161.95175"
+         sodipodi:role="line"
+         id="tspan14366-20-9-5-8-1-5" /></text>
+    <g
+       style="display:inline;opacity:1"
+       id="g17341"
+       transform="translate(555.38736,9.6920925)">
+      <text
+         id="text14730-7-7-5"
+         y="198.1947"
+         x="-531.85492"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="198.1947"
+           x="-531.85492"
+           id="tspan14728-1-9-0"
+           sodipodi:role="line">e48</tspan></text>
+      <text
+         id="text14730-7-4-7-8"
+         y="153.74976"
+         x="-531.83221"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="153.74976"
+           x="-531.83221"
+           id="tspan14728-1-2-6-0"
+           sodipodi:role="line">e72</tspan></text>
+      <text
+         id="text14730-7-4-1-7-5"
+         y="109.29344"
+         x="-531.87769"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="109.29344"
+           x="-531.87769"
+           id="tspan14728-1-2-3-4-1"
+           sodipodi:role="line">e96</tspan></text>
+      <text
+         id="text14730-7-4-1-3-2-4"
+         y="64.844368"
+         x="-531.82806"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="64.844368"
+           x="-531.82806"
+           id="tspan14728-1-2-3-5-4-6"
+           sodipodi:role="line">e120</tspan></text>
+      <text
+         id="text14730-1-6-1"
+         y="287.0939"
+         x="-531.82806"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="287.0939"
+           x="-531.82806"
+           id="tspan14728-0-7-7"
+           sodipodi:role="line">e0</tspan><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="287.49664"
+           x="-531.82806"
+           sodipodi:role="line"
+           id="tspan15564-2-0" /></text>
+      <text
+         id="text14730-7-4-1-3-6-1-4"
+         y="20.372528"
+         x="-531.90247"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="20.372528"
+           x="-531.90247"
+           id="tspan14728-1-2-3-5-7-4-8"
+           sodipodi:role="line">e144</tspan></text>
+      <text
+         id="text14730-73-0"
+         y="242.64998"
+         x="-531.90247"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="242.64998"
+           x="-531.90247"
+           id="tspan14728-7-5"
+           sodipodi:role="line">e24</tspan></text>
+      <text
+         id="text14730-73-0-2"
+         y="264.87503"
+         x="-531.83221"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="264.87503"
+           x="-531.83221"
+           id="tspan14728-7-5-0"
+           sodipodi:role="line">e12</tspan></text>
+      <text
+         id="text14730-73-0-2-2"
+         y="220.41975"
+         x="-531.87769"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="220.41975"
+           x="-531.87769"
+           id="tspan14728-7-5-0-7"
+           sodipodi:role="line">e36</tspan></text>
+      <text
+         id="text14730-73-0-2-6"
+         y="175.96861"
+         x="-531.82806"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="175.96861"
+           x="-531.82806"
+           id="tspan14728-7-5-0-5"
+           sodipodi:role="line">e60</tspan></text>
+      <text
+         id="text14730-73-0-2-4"
+         y="131.51953"
+         x="-531.90247"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="131.51953"
+           x="-531.90247"
+           id="tspan14728-7-5-0-4"
+           sodipodi:role="line">e84</tspan></text>
+      <text
+         id="text14730-73-0-2-9"
+         y="87.069412"
+         x="-531.85492"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="87.069412"
+           x="-531.85492"
+           id="tspan14728-7-5-0-73"
+           sodipodi:role="line">e108</tspan></text>
+      <text
+         id="text14730-73-0-2-95"
+         y="42.619301"
+         x="-531.83221"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:4.23333311px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="42.619301"
+           x="-531.83221"
+           id="tspan14728-7-5-0-2"
+           sodipodi:role="line">e132</tspan></text>
+      <text
+         id="text14730-73-0-2-8"
+         y="275.72333"
+         x="-531.91656"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="275.72333"
+           x="-531.91656"
+           id="tspan14728-7-5-0-47"
+           sodipodi:role="line">e6</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1"
+         y="253.50085"
+         x="-531.89764"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="253.50085"
+           x="-531.89764"
+           id="tspan14728-7-5-0-47-0"
+           sodipodi:role="line">e18</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3"
+         y="231.2758"
+         x="-531.87524"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="231.2758"
+           x="-531.87524"
+           id="tspan14728-7-5-0-47-0-8"
+           sodipodi:role="line">e30</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9"
+         y="209.05505"
+         x="-531.87872"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="209.05505"
+           x="-531.87872"
+           id="tspan14728-7-5-0-47-0-8-6"
+           sodipodi:role="line">e42</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9"
+         y="186.79898"
+         x="-531.93726"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="186.79898"
+           x="-531.93726"
+           id="tspan14728-7-5-0-47-0-8-6-8"
+           sodipodi:role="line">e54</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9"
+         y="164.59804"
+         x="-531.91656"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="164.59804"
+           x="-531.91656"
+           id="tspan14728-7-5-0-47-0-8-6-8-0"
+           sodipodi:role="line">e66</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9-5"
+         y="142.37556"
+         x="-531.89764"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="142.37556"
+           x="-531.89764"
+           id="tspan14728-7-5-0-47-0-8-6-8-0-7"
+           sodipodi:role="line">e78</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9-5-9"
+         y="120.14966"
+         x="-531.87524"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="120.14966"
+           x="-531.87524"
+           id="tspan14728-7-5-0-47-0-8-6-8-0-7-2"
+           sodipodi:role="line">e90</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9-5-9-1"
+         y="97.925461"
+         x="-531.87872"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="97.925461"
+           x="-531.87872"
+           id="tspan14728-7-5-0-47-0-8-6-8-0-7-2-1"
+           sodipodi:role="line">e102</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9-5-9-1-4"
+         y="75.68232"
+         x="-531.93726"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="75.68232"
+           x="-531.93726"
+           id="tspan14728-7-5-0-47-0-8-6-8-0-7-2-1-0"
+           sodipodi:role="line">e114</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9-5-9-1-4-0"
+         y="53.475349"
+         x="-531.91656"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="53.475349"
+           x="-531.91656"
+           id="tspan14728-7-5-0-47-0-8-6-8-0-7-2-1-0-8"
+           sodipodi:role="line">e126</tspan></text>
+      <text
+         id="text14730-73-0-2-8-1-3-9-9-9-5-9-1-4-0-6"
+         y="31.250284"
+         x="-531.89764"
+         style="font-style:normal;font-weight:normal;font-size:3.52777767px;line-height:0.2px;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-size:3.52777767px;text-align:end;text-anchor:end;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+           y="31.250284"
+           x="-531.89764"
+           id="tspan14728-7-5-0-47-0-8-6-8-0-7-2-1-0-8-6"
+           sodipodi:role="line">e138</tspan></text>
+    </g>
+    <g
+       style="display:inline"
+       id="g17463"
+       transform="matrix(1.0003905,0,0,1,554.60492,9.1629258)"
+       inkscape:label="g17463">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-528.81171"
+         y="291.42404"
+         id="text14396-1"><tspan
+           sodipodi:role="line"
+           id="tspan14397-0"
+           x="-528.81171"
+           y="291.42404"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332">100</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-520.24872"
+         y="291.53137"
+         id="text15352"><tspan
+           sodipodi:role="line"
+           x="-520.24872"
+           y="291.53137"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14398-0">101</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-511.87372"
+         y="291.46024"
+         id="text15355"><tspan
+           sodipodi:role="line"
+           x="-511.87372"
+           y="291.46024"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14400-3">102</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-503.38013"
+         y="291.44815"
+         id="text15358"><tspan
+           sodipodi:role="line"
+           x="-503.38013"
+           y="291.44815"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14402-3">103</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-494.97162"
+         y="291.38184"
+         id="text15361"><tspan
+           sodipodi:role="line"
+           x="-494.97162"
+           y="291.38184"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14404-2">104</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-486.45004"
+         y="291.39993"
+         id="text15364"><tspan
+           sodipodi:role="line"
+           x="-486.45004"
+           y="291.39993"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14406-3">105</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-478.01797"
+         y="291.3927"
+         id="text15367"><tspan
+           sodipodi:role="line"
+           x="-478.01797"
+           y="291.3927"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14408-7">106</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-469.52771"
+         y="291.41803"
+         id="text15370"><tspan
+           sodipodi:role="line"
+           x="-469.52771"
+           y="291.41803"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14410-0">107</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-461.06543"
+         y="291.40958"
+         id="text15373"><tspan
+           sodipodi:role="line"
+           x="-461.06543"
+           y="291.40958"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14412-9">108</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-452.58078"
+         y="291.42645"
+         id="text15376"><tspan
+           sodipodi:role="line"
+           x="-452.58078"
+           y="291.42645"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14414-2">109</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-444.23389"
+         y="291.29141"
+         id="text15379"><tspan
+           sodipodi:role="line"
+           x="-444.23389"
+           y="291.29141"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14416-4">110</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-435.67084"
+         y="291.36136"
+         id="text15382"><tspan
+           sodipodi:role="line"
+           x="-435.67084"
+           y="291.36136"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14418-7">111</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-427.29587"
+         y="291.29019"
+         id="text15385"><tspan
+           sodipodi:role="line"
+           x="-427.29587"
+           y="291.29019"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14420-5">112</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-418.80231"
+         y="291.31552"
+         id="text15388"><tspan
+           sodipodi:role="line"
+           x="-418.80231"
+           y="291.31552"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14422-1">113</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-410.39374"
+         y="291.21182"
+         id="text15391"><tspan
+           sodipodi:role="line"
+           x="-410.39374"
+           y="291.21182"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14424-2">114</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-401.87216"
+         y="291.2673"
+         id="text15394"><tspan
+           sodipodi:role="line"
+           x="-401.87216"
+           y="291.2673"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14426-1">115</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-393.44012"
+         y="291.26007"
+         id="text15397"><tspan
+           sodipodi:role="line"
+           x="-393.44012"
+           y="291.26007"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14428-6">116</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-384.94989"
+         y="291.24802"
+         id="text15400"><tspan
+           sodipodi:role="line"
+           x="-384.94989"
+           y="291.24802"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14430-0">117</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-376.48764"
+         y="291.27695"
+         id="text15403"><tspan
+           sodipodi:role="line"
+           x="-376.48764"
+           y="291.27695"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14432-7">118</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-368.00296"
+         y="291.29141"
+         id="text15406"><tspan
+           sodipodi:role="line"
+           x="-368.00296"
+           y="291.29141"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14434-6">119</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-359.4769"
+         y="291.35172"
+         id="text15409"><tspan
+           sodipodi:role="line"
+           x="-359.4769"
+           y="291.35172"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14436-8">120</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-350.91382"
+         y="291.44937"
+         id="text15412"><tspan
+           sodipodi:role="line"
+           x="-350.91382"
+           y="291.44937"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14438-3">121</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-342.53891"
+         y="291.35049"
+         id="text15415"><tspan
+           sodipodi:role="line"
+           x="-342.53891"
+           y="291.35049"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14440-6">122</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-334.04529"
+         y="291.37582"
+         id="text15418"><tspan
+           sodipodi:role="line"
+           x="-334.04529"
+           y="291.37582"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14442-0">123</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-325.63678"
+         y="291.30588"
+         id="text15421"><tspan
+           sodipodi:role="line"
+           x="-325.63678"
+           y="291.30588"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14444-0">124</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-317.11517"
+         y="291.36136"
+         id="text15424"><tspan
+           sodipodi:role="line"
+           x="-317.11517"
+           y="291.36136"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14446-9">125</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-308.68317"
+         y="291.32034"
+         id="text15427"><tspan
+           sodipodi:role="line"
+           x="-308.68317"
+           y="291.32034"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14448-8">126</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-300.1929"
+         y="291.34204"
+         id="text15430"><tspan
+           sodipodi:role="line"
+           x="-300.1929"
+           y="291.34204"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14450-5">127</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-291.73062"
+         y="291.33722"
+         id="text15433"><tspan
+           sodipodi:role="line"
+           x="-291.73062"
+           y="291.33722"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14452-3">128</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-283.246"
+         y="291.35172"
+         id="text15436"><tspan
+           sodipodi:role="line"
+           x="-283.246"
+           y="291.35172"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14454-2">129</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-274.79492"
+         y="291.33121"
+         id="text15439"><tspan
+           sodipodi:role="line"
+           x="-274.79492"
+           y="291.33121"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14456-9">130</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-266.23187"
+         y="291.43851"
+         id="text15442"><tspan
+           sodipodi:role="line"
+           x="-266.23187"
+           y="291.43851"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14458-4">131</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-257.85693"
+         y="291.36737"
+         id="text15445"><tspan
+           sodipodi:role="line"
+           x="-257.85693"
+           y="291.36737"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14460-9">132</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-249.36334"
+         y="291.35532"
+         id="text15448"><tspan
+           sodipodi:role="line"
+           x="-249.36334"
+           y="291.35532"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14462-6">133</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-240.9548"
+         y="291.289"
+         id="text15451"><tspan
+           sodipodi:role="line"
+           x="-240.9548"
+           y="291.289"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14464-4">134</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-232.43321"
+         y="291.3071"
+         id="text15454"><tspan
+           sodipodi:role="line"
+           x="-232.43321"
+           y="291.3071"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14466-6">135</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-224.00117"
+         y="291.29987"
+         id="text15457"><tspan
+           sodipodi:role="line"
+           x="-224.00117"
+           y="291.29987"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14468-3">136</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-215.51091"
+         y="291.32516"
+         id="text15460"><tspan
+           sodipodi:role="line"
+           x="-215.51091"
+           y="291.32516"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14470-0">137</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-207.04865"
+         y="291.31674"
+         id="text15463"><tspan
+           sodipodi:role="line"
+           x="-207.04865"
+           y="291.31674"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14472-5">138</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-198.564"
+         y="291.33362"
+         id="text15466"><tspan
+           sodipodi:role="line"
+           x="-198.564"
+           y="291.33362"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14474-8">139</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-190.05809"
+         y="291.371"
+         id="text15469"><tspan
+           sodipodi:role="line"
+           x="-190.05809"
+           y="291.371"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14476-1">140</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-181.49504"
+         y="291.47107"
+         id="text15472"><tspan
+           sodipodi:role="line"
+           x="-181.49504"
+           y="291.47107"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14478-0">141</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-173.12012"
+         y="291.36859"
+         id="text15475"><tspan
+           sodipodi:role="line"
+           x="-173.12012"
+           y="291.36859"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14480-7">142</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-164.62651"
+         y="291.39389"
+         id="text15478"><tspan
+           sodipodi:role="line"
+           x="-164.62651"
+           y="291.39389"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14482-3">143</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-156.21797"
+         y="291.32758"
+         id="text15481"><tspan
+           sodipodi:role="line"
+           x="-156.21797"
+           y="291.32758"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14484-3">144</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-147.69638"
+         y="291.38306"
+         id="text15484"><tspan
+           sodipodi:role="line"
+           x="-147.69638"
+           y="291.38306"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14486-6">145</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-139.26436"
+         y="291.34204"
+         id="text15487"><tspan
+           sodipodi:role="line"
+           x="-139.26436"
+           y="291.34204"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14488-7">146</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-130.77408"
+         y="291.36377"
+         id="text15490"><tspan
+           sodipodi:role="line"
+           x="-130.77408"
+           y="291.36377"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14490-7">147</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-122.31183"
+         y="291.35532"
+         id="text15493"><tspan
+           sodipodi:role="line"
+           x="-122.31183"
+           y="291.35532"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14492-1">148</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-113.82718"
+         y="291.371"
+         id="text15496"><tspan
+           sodipodi:role="line"
+           x="-113.82718"
+           y="291.371"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14494-9">149</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-105.34698"
+         y="291.38065"
+         id="text15499"><tspan
+           sodipodi:role="line"
+           x="-105.34698"
+           y="291.38065"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14496-6">150</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-96.783958"
+         y="291.48312"
+         id="text15502"><tspan
+           sodipodi:role="line"
+           x="-96.783958"
+           y="291.48312"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14498-4">151</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-88.409042"
+         y="291.38184"
+         id="text15505"><tspan
+           sodipodi:role="line"
+           x="-88.409042"
+           y="291.38184"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14500-0">152</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-79.915405"
+         y="291.40475"
+         id="text15508"><tspan
+           sodipodi:role="line"
+           x="-79.915405"
+           y="291.40475"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14502-0">153</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-71.506897"
+         y="291.33963"
+         id="text15511"><tspan
+           sodipodi:role="line"
+           x="-71.506897"
+           y="291.33963"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14504-6">154</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-62.985302"
+         y="291.3927"
+         id="text15514"><tspan
+           sodipodi:role="line"
+           x="-62.985302"
+           y="291.3927"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14506-3">155</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-54.553246"
+         y="291.35172"
+         id="text15517"><tspan
+           sodipodi:role="line"
+           x="-54.553246"
+           y="291.35172"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14508-6">156</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-46.063007"
+         y="291.37582"
+         id="text15520"><tspan
+           sodipodi:role="line"
+           x="-46.063007"
+           y="291.37582"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14510-5">157</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-37.600754"
+         y="291.36618"
+         id="text15523"><tspan
+           sodipodi:role="line"
+           x="-37.600754"
+           y="291.36618"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14512-5">158</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.58611107px;line-height:1.71500003;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-29.116106"
+         y="291.38306"
+         id="text15526"><tspan
+           sodipodi:role="line"
+           x="-29.116106"
+           y="291.38306"
+           style="font-size:3.88055563px;line-height:1.71500003;stroke-width:0.26458332"
+           id="tspan14514-1">159</tspan></text>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="title"
+     style="display:inline;opacity:1"
+     transform="translate(0,8.4666667)"
+     sodipodi:insensitive="true">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.11111069px;line-height:2.64583325px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="276.93887"
+       y="15.307935"
+       id="text5201"><tspan
+         sodipodi:role="line"
+         id="tspan5349"
+         x="276.93887"
+         y="15.307935">Post-Post-Ascension Production Guide</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer16"
+     inkscape:label="labels"
+     style="display:none"
+     transform="translate(0,40.216667)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="234.79564"
+       y="68.89122"
+       id="text33265-7-2-2"><tspan
+         sodipodi:role="line"
+         id="tspan33263-2-1-4"
+         x="234.79564"
+         y="68.89122"
+         style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Angel Research</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="273.83377"
+       y="50.634975"
+       id="text33265-7-2-2-8"><tspan
+         sodipodi:role="line"
+         id="tspan33263-2-1-4-1"
+         x="273.83377"
+         y="50.634975"
+         style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Titan Research</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="343.68997"
+       y="19.560215"
+       id="text33265-7-2-2-8-5"><tspan
+         sodipodi:role="line"
+         id="tspan33263-2-1-4-1-0"
+         x="343.68997"
+         y="19.560215"
+         style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Dwangel Research</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 327.08643,48.34904 22.77022,32.135191"
+       id="path33700"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 409.78753,16.693057 41.75972,2.201004"
+       id="path33700-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 290.68836,66.549353 37.45669,15.484299"
+       id="path33700-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 180.18124,128.5875 31.22084,15.875"
+       id="path33700-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="193.71344"
+       y="83.961922"
+       id="text33265-7-2-2-85"><tspan
+         sodipodi:role="line"
+         id="tspan33263-2-1-4-5"
+         x="193.71344"
+         y="83.961922"
+         style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Goblin Research</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 251.19365,81.620059 37.45669,15.4843"
+       id="path33700-2-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       id="text33265-7-3"
+       y="123.38301"
+       x="152.31973"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.44999999;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-size:5.64444447px;line-height:0.44999999;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="123.38301"
+         x="152.31973"
+         sodipodi:role="line"
+         id="tspan4802-4"><tspan
+           id="tspan4864"
+           style="font-size:7.05555534px;line-height:0.44999999;text-align:center;text-anchor:middle;stroke-width:0.26458332">Mercenary</tspan></tspan><tspan
+         style="font-size:5.64444447px;line-height:0.44999999;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="130.17279"
+         x="152.31973"
+         sodipodi:role="line"
+         id="tspan5083">LF/EF (Stronger)</tspan><tspan
+         style="font-size:5.64444447px;line-height:0.44999999;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="137.05052"
+         x="152.31973"
+         sodipodi:role="line"
+         id="tspan5085">TF (Idle)</tspan></text>
+    <text
+       id="text33265-7-3-7"
+       y="176.29396"
+       x="74.479156"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.69999999;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-size:5.64444447px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="176.29396"
+         x="74.479156"
+         sodipodi:role="line"
+         id="tspan4802-4-1"><tspan
+   id="tspan4864-6"
+   style="font-size:7.05555534px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332">Mercenary </tspan>(DF)</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 102.12466,173.83029 7.37945,22.76251"
+       id="path33700-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:0.01417323;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="296.15692"
+       y="32.765064"
+       id="text33265-7-2-2-8-5-2"><tspan
+         sodipodi:role="line"
+         id="tspan33263-2-1-4-1-0-7"
+         x="296.15692"
+         y="32.765064"
+         style="font-size:7.05555534px;line-height:0.01417323;stroke-width:0.26458332">Dwairy Research</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 358.05965,30.274863 78.09895,0.327848"
+       id="path33700-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 358.05965,30.274863 35.97397,20.182519"
+       id="path33700-1-2-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 358.05965,30.274863 14.73008,31.389464"
+       id="path33700-1-2-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="uni labels"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="markers"
+     style="display:none"
+     transform="translate(0,40.216667)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.11111069px;line-height:2.64583325px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="486.83328"
+       y="10.583331"
+       id="text5064"><tspan
+         sodipodi:role="line"
+         id="tspan5062"
+         x="486.83328"
+         y="15.960797"
+         style="stroke-width:0.26458332" /></text>
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g4911-0"
+       id="use5320"
+       transform="translate(-324.2598,121.77414)"
+       width="100%"
+       height="100%"
+       style="display:inline" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g4911-0-7"
+       id="use5337"
+       width="100%"
+       height="100%"
+       transform="translate(-145.86976,23.996173)"
+       inkscape:transform-center-x="-3.0742146"
+       inkscape:transform-center-y="-12.296859"
+       style="display:inline" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g5149"
+       id="use5354"
+       transform="translate(-19.302956,-86.038527)"
+       width="100%"
+       height="100%"
+       style="display:inline" />
+    <g
+       style="display:none"
+       id="use5356"
+       transform="translate(-414.49586,145.04705)">
+      <circle
+         r="3.5672603"
+         cy="63.97374"
+         cx="589.12085"
+         id="circle2474"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text2478"
+         y="66.261932"
+         x="589.00098"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="66.261932"
+           x="589.00098"
+           id="tspan2476"
+           sodipodi:role="line">F</tspan></text>
+    </g>
+    <g
+       style="display:none"
+       id="use5437"
+       transform="translate(-372.16254,187.38039)">
+      <circle
+         r="3.5672603"
+         cy="74.557076"
+         cx="589.12085"
+         id="circle2466"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text2470"
+         y="76.845268"
+         x="588.99023"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="76.845268"
+           x="588.99023"
+           id="tspan2468"
+           sodipodi:role="line">G</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:2.64583325px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="486.83328"
+       y="89.958336"
+       id="text5456"><tspan
+         sodipodi:role="line"
+         id="tspan5454"
+         x="486.83328"
+         y="92.700348"
+         style="stroke-width:0.26458332" /></text>
+    <g
+       style="display:none"
+       id="use5518"
+       transform="translate(-350.99586,20.692934)">
+      <g
+         id="g2462">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2455"
+           cx="589.12085"
+           cy="101.0154"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="589.1239"
+           y="103.3036"
+           id="text2460"><tspan
+             sodipodi:role="line"
+             id="tspan2457"
+             x="589.1239"
+             y="103.3036"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">I</tspan></text>
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g7791-3"
+       transform="translate(-429.42171,186.58337)">
+      <circle
+         r="3.5672603"
+         cy="22.170212"
+         cx="509.9408"
+         id="path4887-1-1"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text4906-7-0"
+         y="24.458405"
+         x="509.67188"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="24.458405"
+           x="509.67188"
+           id="tspan4904-0-3"
+           sodipodi:role="line">A</tspan></text>
+    </g>
+    <g
+       style="display:none"
+       id="use5216"
+       transform="translate(-182.73442,291.8612)">
+      <g
+         id="g2425"
+         transform="translate(1.0718931,-120.35577)">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2419"
+           cx="589.12085"
+           cy="90.432076"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="589.1239"
+           y="92.720268"
+           id="text2423"><tspan
+             sodipodi:role="line"
+             id="tspan2421"
+             x="589.1239"
+             y="92.720268"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">N</tspan></text>
+      </g>
+    </g>
+    <g
+       style="display:none"
+       id="use5218"
+       transform="translate(-361.57922,23.33876)">
+      <circle
+         r="3.5672603"
+         cy="127.47373"
+         cx="578.53754"
+         id="circle2437"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text2441"
+         y="129.76193"
+         x="578.53906"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="129.76193"
+           x="578.53906"
+           id="tspan2439"
+           sodipodi:role="line">H</tspan></text>
+    </g>
+    <g
+       style="display:none"
+       id="use5255"
+       transform="translate(-276.91254,-42.8071)">
+      <g
+         id="g2451">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2445"
+           cx="589.12085"
+           cy="127.47374"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="588.84119"
+           y="129.76193"
+           id="text2449"><tspan
+             sodipodi:role="line"
+             id="tspan2447"
+             x="588.84119"
+             y="129.76193"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">K</tspan></text>
+      </g>
+    </g>
+    <g
+       style="display:none"
+       id="use5257"
+       transform="translate(-192.24588,-106.30711)">
+      <circle
+         r="3.5672603"
+         cy="148.64041"
+         cx="589.12085"
+         id="circle2411"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text2415"
+         y="150.9286"
+         x="589.1239"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="150.9286"
+           x="589.1239"
+           id="tspan2413"
+           sodipodi:role="line">M</tspan></text>
+    </g>
+    <g
+       style="display:none"
+       id="use5788"
+       transform="translate(-287.49585,-21.64041)">
+      <circle
+         r="3.5672603"
+         cy="111.59874"
+         cx="589.12085"
+         id="circle2429"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text2433"
+         y="113.85467"
+         x="589.33905"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="113.85467"
+           x="589.33905"
+           id="tspan2431"
+           sodipodi:role="line">J</tspan></text>
+    </g>
+    <g
+       style="display:none"
+       id="use5847"
+       transform="translate(-234.57922,-32.22374)">
+      <circle
+         r="3.5672603"
+         cy="95.72374"
+         cx="589.12085"
+         id="circle2403"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         id="text2407"
+         y="98.01194"
+         x="588.81042"
+         style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+           y="98.01194"
+           x="588.81042"
+           id="tspan2405"
+           sodipodi:role="line">L</tspan></text>
+    </g>
+    <use
+       style="display:inline"
+       height="100%"
+       width="100%"
+       transform="translate(-86.935678,-40.503855)"
+       id="use5676"
+       xlink:href="#g5487"
+       y="0"
+       x="0" />
+    <text
+       id="text14396"
+       y="-44.258827"
+       x="-743.15521"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.5;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="-44.258827"
+         x="-743.15521"
+         id="tspan14394"
+         sodipodi:role="line">40</tspan><tspan
+         id="tspan14398"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="-36.850494"
+         x="-743.15521"
+         sodipodi:role="line">41</tspan><tspan
+         id="tspan14400"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="-29.442162"
+         x="-743.15521"
+         sodipodi:role="line">42</tspan><tspan
+         id="tspan14402"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="-22.033829"
+         x="-743.15521"
+         sodipodi:role="line">43</tspan><tspan
+         id="tspan14404"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="-14.625496"
+         x="-743.15521"
+         sodipodi:role="line">44</tspan><tspan
+         id="tspan14406"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="-7.2171631"
+         x="-743.15521"
+         sodipodi:role="line">45</tspan><tspan
+         id="tspan14408"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="0.19116974"
+         x="-743.15521"
+         sodipodi:role="line">46</tspan><tspan
+         id="tspan14410"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="7.5995026"
+         x="-743.15521"
+         sodipodi:role="line">47</tspan><tspan
+         id="tspan14412"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="15.007835"
+         x="-743.15521"
+         sodipodi:role="line">48</tspan><tspan
+         id="tspan14414"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="22.416168"
+         x="-743.15521"
+         sodipodi:role="line">49</tspan><tspan
+         id="tspan14416"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="29.824501"
+         x="-743.15521"
+         sodipodi:role="line">50</tspan><tspan
+         id="tspan14418"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="37.232834"
+         x="-743.15521"
+         sodipodi:role="line">51</tspan><tspan
+         id="tspan14420"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="44.641167"
+         x="-743.15521"
+         sodipodi:role="line">52</tspan><tspan
+         id="tspan14422"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="52.0495"
+         x="-743.15521"
+         sodipodi:role="line">53</tspan><tspan
+         id="tspan14424"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="59.457832"
+         x="-743.15521"
+         sodipodi:role="line">54</tspan><tspan
+         id="tspan14426"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="66.866165"
+         x="-743.15521"
+         sodipodi:role="line">55</tspan><tspan
+         id="tspan14428"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="74.274498"
+         x="-743.15521"
+         sodipodi:role="line">56</tspan><tspan
+         id="tspan14430"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="81.682831"
+         x="-743.15521"
+         sodipodi:role="line">57</tspan><tspan
+         id="tspan14432"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="89.091164"
+         x="-743.15521"
+         sodipodi:role="line">58</tspan><tspan
+         id="tspan14434"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="96.499496"
+         x="-743.15521"
+         sodipodi:role="line">59</tspan><tspan
+         id="tspan14436"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="103.90783"
+         x="-743.15521"
+         sodipodi:role="line">60</tspan><tspan
+         id="tspan14438"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="111.31616"
+         x="-743.15521"
+         sodipodi:role="line">61</tspan><tspan
+         id="tspan14440"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="118.72449"
+         x="-743.15521"
+         sodipodi:role="line">62</tspan><tspan
+         id="tspan14442"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="126.13283"
+         x="-743.15521"
+         sodipodi:role="line">63</tspan><tspan
+         id="tspan14444"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="133.54117"
+         x="-743.15521"
+         sodipodi:role="line">64</tspan><tspan
+         id="tspan14446"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="140.94949"
+         x="-743.15521"
+         sodipodi:role="line">65</tspan><tspan
+         id="tspan14448"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="148.35782"
+         x="-743.15521"
+         sodipodi:role="line">66</tspan><tspan
+         id="tspan14450"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="155.76616"
+         x="-743.15521"
+         sodipodi:role="line">67</tspan><tspan
+         id="tspan14452"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="163.1745"
+         x="-743.15521"
+         sodipodi:role="line">68</tspan><tspan
+         id="tspan14454"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="170.58282"
+         x="-743.15521"
+         sodipodi:role="line">69</tspan><tspan
+         id="tspan14456"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="177.99115"
+         x="-743.15521"
+         sodipodi:role="line">70</tspan><tspan
+         id="tspan14458"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="185.39949"
+         x="-743.15521"
+         sodipodi:role="line">71</tspan><tspan
+         id="tspan14460"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="192.80783"
+         x="-743.15521"
+         sodipodi:role="line">72</tspan><tspan
+         id="tspan14462"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="200.21616"
+         x="-743.15521"
+         sodipodi:role="line">73</tspan><tspan
+         id="tspan14464"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="207.62448"
+         x="-743.15521"
+         sodipodi:role="line">74</tspan><tspan
+         id="tspan14466"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="215.03282"
+         x="-743.15521"
+         sodipodi:role="line">75</tspan><tspan
+         id="tspan14468"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="222.44116"
+         x="-743.15521"
+         sodipodi:role="line">76</tspan><tspan
+         id="tspan14470"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="229.84949"
+         x="-743.15521"
+         sodipodi:role="line">77</tspan><tspan
+         id="tspan14472"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="237.25781"
+         x="-743.15521"
+         sodipodi:role="line">78</tspan><tspan
+         id="tspan14474"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="244.66615"
+         x="-743.15521"
+         sodipodi:role="line">79</tspan><tspan
+         id="tspan14476"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="252.07449"
+         x="-743.15521"
+         sodipodi:role="line">80</tspan><tspan
+         id="tspan14478"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="259.48282"
+         x="-743.15521"
+         sodipodi:role="line">81</tspan><tspan
+         id="tspan14480"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="266.89114"
+         x="-743.15521"
+         sodipodi:role="line">82</tspan><tspan
+         id="tspan14482"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="274.2995"
+         x="-743.15521"
+         sodipodi:role="line">83</tspan><tspan
+         id="tspan14484"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="281.70782"
+         x="-743.15521"
+         sodipodi:role="line">84</tspan><tspan
+         id="tspan14486"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="289.11615"
+         x="-743.15521"
+         sodipodi:role="line">85</tspan><tspan
+         id="tspan14488"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="296.52448"
+         x="-743.15521"
+         sodipodi:role="line">86</tspan><tspan
+         id="tspan14490"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="303.9328"
+         x="-743.15521"
+         sodipodi:role="line">87</tspan><tspan
+         id="tspan14492"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="311.34116"
+         x="-743.15521"
+         sodipodi:role="line">88</tspan><tspan
+         id="tspan14494"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="318.74948"
+         x="-743.15521"
+         sodipodi:role="line">89</tspan><tspan
+         id="tspan14496"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="326.15781"
+         x="-743.15521"
+         sodipodi:role="line">90</tspan><tspan
+         id="tspan14498"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="333.56616"
+         x="-743.15521"
+         sodipodi:role="line">91</tspan><tspan
+         id="tspan14500"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="340.97449"
+         x="-743.15521"
+         sodipodi:role="line">92</tspan><tspan
+         id="tspan14502"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="348.38281"
+         x="-743.15521"
+         sodipodi:role="line">93</tspan><tspan
+         id="tspan14504"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="355.79114"
+         x="-743.15521"
+         sodipodi:role="line">94</tspan><tspan
+         id="tspan14506"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="363.19946"
+         x="-743.15521"
+         sodipodi:role="line">95</tspan><tspan
+         id="tspan14508"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="370.60782"
+         x="-743.15521"
+         sodipodi:role="line">96</tspan><tspan
+         id="tspan14510"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="378.01614"
+         x="-743.15521"
+         sodipodi:role="line">97</tspan><tspan
+         id="tspan14512"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="385.42447"
+         x="-743.15521"
+         sodipodi:role="line">98</tspan><tspan
+         id="tspan14514"
+         style="line-height:1.5;stroke-width:0.26458332"
+         y="392.83282"
+         x="-743.15521"
+         sodipodi:role="line">99</tspan></text>
+    <flowRoot
+       style="font-style:normal;font-weight:normal;font-size:18.66666603px;line-height:9px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot14516"
+       xml:space="preserve"><flowRegion
+         id="flowRegion14518"><rect
+           y="50.715725"
+           x="-2927.3438"
+           height="789.09192"
+           width="503.85287"
+           id="rect14520" /></flowRegion><flowPara
+         id="flowPara14522" /></flowRoot>  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="todo"
+     style="display:none"
+     transform="translate(0,8.4666667)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:7.76111126px;line-height:0.07500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="551.81238"
+       y="131.26382"
+       id="text5026"><tspan
+         sodipodi:role="line"
+         id="tspan5024"
+         x="551.81238"
+         y="131.26382"
+         style="font-size:7.76111126px;stroke-width:0.26458332">Things to Do</tspan></text>
+    <g
+       id="g5512"
+       transform="translate(74.461326,97.511682)"
+       style="display:inline">
+      <g
+         id="g4911-0"
+         style="display:inline"
+         transform="translate(496.81662,-123.01907)">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4887-5"
+           cx="-24.712446"
+           cy="180.39041"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="-24.712446"
+           y="182.6786"
+           id="text4906-0"><tspan
+             sodipodi:role="line"
+             id="tspan4904-9"
+             x="-24.712446"
+             y="182.6786"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">B</tspan></text>
+      </g>
+      <g
+         transform="translate(0,48.960119)"
+         id="g5869"
+         style="display:inline">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="477.90601"
+           y="8.4204798"
+           id="text5068"><tspan
+             sodipodi:role="line"
+             x="477.90601"
+             y="8.4204798"
+             style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+             id="tspan5078">end of R54</tspan><tspan
+             sodipodi:role="line"
+             x="477.90601"
+             y="14.070479"
+             style="line-height:5.6500001px;stroke-width:0.26458332"
+             id="tspan5082">DC2 Unlock</tspan><tspan
+             sodipodi:role="line"
+             x="477.90601"
+             y="19.72048"
+             style="line-height:5.6500001px;stroke-width:0.26458332"
+             id="tspan2532">DC3 Unlock + Tier 6 Unlock</tspan></text>
+      </g>
+    </g>
+    <g
+       id="g5525"
+       transform="translate(74.461326,97.643972)"
+       style="display:inline">
+      <g
+         id="g4911-0-7"
+         style="display:inline"
+         transform="translate(496.81662,-102.29295)">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4887-5-1"
+           cx="-24.712446"
+           cy="180.39041"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="-24.712446"
+           y="182.6786"
+           id="text4906-0-9"><tspan
+             sodipodi:role="line"
+             id="tspan4904-9-4"
+             x="-24.712446"
+             y="182.6786"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">C</tspan></text>
+      </g>
+      <text
+         id="text5068-8"
+         y="46.35672"
+         x="477.90601"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"
+         transform="translate(0,31.75)"><tspan
+           id="tspan5082-6"
+           style="font-style:italic;font-weight:normal;line-height:5.6500001px;stroke-width:0.26458332"
+           y="46.35672"
+           x="477.90601"
+           sodipodi:role="line">end of R75</tspan><tspan
+           id="tspan5318"
+           style="font-weight:bold;line-height:5.6500001px;stroke-width:0.26458332"
+           y="52.006721"
+           x="477.90601"
+           sodipodi:role="line">Mercenary Unlock</tspan><tspan
+           style="font-weight:normal;line-height:5.6500001px;stroke-width:0.26458332"
+           y="57.656719"
+           x="477.90601"
+           sodipodi:role="line"
+           id="tspan2543">We Shall Rise Again + L20 Lineages</tspan><tspan
+           id="tspan7885"
+           style="line-height:5.6500001px;fill:#999999;stroke-width:0.26458332"
+           y="63.306721"
+           x="477.90601"
+           sodipodi:role="line" /></text>
+    </g>
+    <g
+       id="g5538"
+       transform="translate(74.461326,77.536432)"
+       style="display:inline">
+      <g
+         transform="translate(496.81662,-64.643359)"
+         style="display:inline"
+         id="g5149">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4887-6"
+           cx="-24.71244"
+           cy="196.26541"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="-24.843063"
+           y="198.5536"
+           id="text4906-1"><tspan
+             sodipodi:role="line"
+             id="tspan4904-8"
+             x="-24.843063"
+             y="198.5536"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">E</tspan></text>
+      </g>
+      <text
+         id="text5068-8-8"
+         y="131.63126"
+         x="478.10135"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-weight:normal;line-height:5.6500001px;stroke-width:0.26458332"
+           y="131.63126"
+           x="478.10135"
+           sodipodi:role="line"
+           id="tspan2553">end of R90</tspan><tspan
+           style="font-style:normal;font-weight:bold;line-height:5.6500001px;stroke-width:0.26458332"
+           y="137.28125"
+           x="478.10135"
+           sodipodi:role="line"
+           id="tspan2557">Excavate Veteran Figurine</tspan><tspan
+           id="tspan5217"
+           style="font-weight:bold;line-height:5.6500001px;stroke-width:0.26458332"
+           y="142.93126"
+           x="478.10135"
+           sodipodi:role="line" /></text>
+    </g>
+    <g
+       id="g5501"
+       transform="translate(74.461326,115.45945)"
+       style="display:inline">
+      <g
+         transform="translate(-37.836613,3.175037)"
+         id="g7791"
+         style="display:inline">
+        <circle
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4887-1"
+           cx="509.9408"
+           cy="22.170212"
+           r="3.5672603" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           x="509.67188"
+           y="24.458405"
+           id="text4906-7"><tspan
+             sodipodi:role="line"
+             id="tspan4904-0"
+             x="509.67188"
+             y="24.458405"
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128">A</tspan></text>
+      </g>
+      <text
+         id="text5068-3"
+         y="-6.3954983"
+         x="477.85538"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:5.6500001px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"
+         inkscape:label="text5068-3"
+         transform="translate(0,31.75)"><tspan
+           sodipodi:role="line"
+           id="tspan2514"
+           x="477.85538"
+           y="-6.3954983"
+           style="font-style:italic">end of R46</tspan><tspan
+           sodipodi:role="line"
+           id="tspan2516"
+           x="477.85538"
+           y="-0.74549848"
+           style="font-style:normal;font-weight:bold">Dragon Unlock</tspan></text>
+    </g>
+    <g
+       id="g5685"
+       transform="translate(74.461326,78.751402)"
+       style="display:inline">
+      <g
+         id="g5487"
+         style="display:inline"
+         transform="translate(496.81662,-80.121459)">
+        <circle
+           r="3.5672603"
+           cy="196.26541"
+           cx="-24.71244"
+           id="circle5481"
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <text
+           id="text5485"
+           y="198.5536"
+           x="-24.763161"
+           style="font-style:normal;font-weight:normal;font-size:6.2944684px;line-height:1.18021286px;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.11802128"
+           xml:space="preserve"><tspan
+             style="text-align:center;text-anchor:middle;stroke-width:0.11802128"
+             y="198.5536"
+             x="-24.763161"
+             id="tspan5483"
+             sodipodi:role="line">D</tspan></text>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="477.90601"
+         y="116.15321"
+         id="text5583"><tspan
+           sodipodi:role="line"
+           x="477.90601"
+           y="116.15321"
+           style="font-style:italic;font-weight:normal;line-height:5.6500001px;stroke-width:0.26458332"
+           id="tspan5579">end of R82</tspan><tspan
+           sodipodi:role="line"
+           x="477.90601"
+           y="121.80322"
+           style="font-weight:normal;line-height:5.6500001px;stroke-width:0.26458332"
+           id="tspan5581">L25 Lineages</tspan></text>
+    </g>
+  </g>
+  <g
+     transform="translate(0,8.4666667)"
+     style="display:none"
+     inkscape:label="A2 PSA"
+     id="g3964"
+     inkscape:groupmode="layer">
+    <text
+       id="text3696"
+       y="38.659313"
+       x="558.84027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;line-height:0.07500001px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         id="tspan4046"
+         x="558.84027"
+         y="38.659313">Things to Do Before Ascension 2</tspan></text>
+    <g
+       transform="translate(65.881254,24.889621)"
+       id="g3836">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:5.6500001px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="474.4158"
+         y="25.354502"
+         id="text3834"><tspan
+           sodipodi:role="line"
+           id="tspan4022"
+           x="474.4158"
+           y="25.354502">Have ALL Lineages at L25+</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4024"
+           x="474.4158"
+           y="31.004501">You won't be able to get them there in A2.</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4026"
+           x="474.4158"
+           y="36.654503" /><tspan
+           sodipodi:role="line"
+           id="tspan4028"
+           x="474.4158"
+           y="42.304501">Some Perk 2 Challenges (L15) are also very hard/impossible.</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4030"
+           x="474.4158"
+           y="47.954502">These are as follows: Elf, Dwarf, Dragon.</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4032"
+           x="474.4158"
+           y="53.6045" /><tspan
+           sodipodi:role="line"
+           id="tspan4034"
+           x="474.4158"
+           y="59.254501">Remember that Assistant and FC trophies aren't doable in A2.</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4036"
+           x="474.4158"
+           y="64.904503" /><tspan
+           sodipodi:role="line"
+           id="tspan4038"
+           x="474.4158"
+           y="70.554497">Spell Master is also impossible due to requiring a VERY long time to do.</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4040"
+           x="474.4158"
+           y="76.204498" /><tspan
+           sodipodi:role="line"
+           id="tspan4042"
+           x="474.4158"
+           y="81.8545">Ruby #26 at 17,550 Excavations (e284 coins with E290)</tspan><tspan
+           sodipodi:role="line"
+           id="tspan4044"
+           x="474.4158"
+           y="87.504501">Ruby #27 is on 18,900 Excavations (e305 coins with E290)</tspan></text>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="todont"
+     style="display:none"
+     transform="translate(0,8.4666667)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:7.76111126px;line-height:0.07500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="646.1178"
+       y="2.1468093"
+       id="text5026-6"><tspan
+         sodipodi:role="line"
+         id="tspan5024-8"
+         x="646.1178"
+         y="2.1468093"
+         style="font-size:7.76111126px;stroke-width:0.26458332">Things to not Do</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="633.6723"
+       y="30.776987"
+       id="text5068-1"><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="30.776987"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5078-6">before Excess of Mana Run (R7-11)</tspan><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="36.426987"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5082-0">Unlock Faceless/Drow</tspan></text>
+    <text
+       id="text5260"
+       y="46.443916"
+       x="633.6723"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         id="tspan5256"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         y="46.443916"
+         x="633.6723"
+         sodipodi:role="line">before R16</tspan><tspan
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         y="52.093918"
+         x="633.6723"
+         sodipodi:role="line"
+         id="tspan5360">Evil Challenges, especially Undead,</tspan><tspan
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         y="57.743916"
+         x="633.6723"
+         sodipodi:role="line"
+         id="tspan5372">Greed Drive, Perfect Combo</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="633.6723"
+       y="14.823106"
+       id="text5068-1-7"><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="14.823106"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5078-6-8">before unlocking Mercenary</tspan><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="20.473106"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5082-0-7">Lightning Storm (Titan Spell Trophy)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="633.6723"
+       y="67.920021"
+       id="text5302"><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="67.920021"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5298">before unlocking D400</tspan><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="73.570023"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5300">Van!shment</tspan></text>
+    <text
+       id="text5308"
+       y="98.882515"
+       x="633.6723"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         id="tspan5304"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         y="98.882515"
+         x="633.6723"
+         sodipodi:role="line">before Dragon Unlock (post-A)</tspan><tspan
+         id="tspan5306"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         y="104.53252"
+         x="633.6723"
+         sodipodi:role="line">Equality, D480, D525, W525</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="633.6723"
+       y="82.928596"
+       id="text5350"><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="82.928596"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5346">before Ascension</tspan><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="88.578598"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5348">Faceless Challenge 4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.6500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="633.6723"
+       y="114.80988"
+       id="text5356"><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="114.80988"
+         style="font-style:italic;line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5352">before late post-A</tspan><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="120.45988"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5354">Beard Carpet, Perfectly Good,</tspan><tspan
+         sodipodi:role="line"
+         x="633.6723"
+         y="126.10989"
+         style="line-height:5.6500001px;stroke-width:0.26458332"
+         id="tspan5358">Diabolical Evil, Lucky Neutral</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="tooffline"
+     style="display:none"
+     transform="translate(0,8.4666667)">
+    <text
+       id="text5378"
+       y="138.90436"
+       x="642.83789"
+       style="font-style:normal;font-weight:normal;font-size:7.76111126px;line-height:0.07500001px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-size:7.76111126px;stroke-width:0.26458332"
+         y="138.90436"
+         x="642.83789"
+         id="tspan5376"
+         sodipodi:role="line">What to do Offline</tspan></text>
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot5420"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:5.4327774px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       transform="translate(72.907939,-22.754168)"><flowRegion
+         id="flowRegion5422"
+         style="line-height:5.4327774px;stroke-width:0.26458332"><rect
+           id="rect5424"
+           width="88.4254"
+           height="132.87596"
+           x="560.91669"
+           y="169.33333"
+           style="line-height:5.4327774px;stroke-width:0.07000434" /></flowRegion><flowPara
+         id="flowPara5426"
+         style="line-height:5.4327774px;stroke-width:0.26458332">* Offline production/mana is almost always useless pre-A</flowPara><flowPara
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5438" /><flowPara
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5440">* The best thing to use offline time for is purely time based requirements, mainly faction playtime</flowPara><flowPara
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5442" /><flowPara
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5444">   1) Be Druid offline until you have 7-7.5 days druid playtime</flowPara><flowPara
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5448">   2) Then be Faceless until you have 14 days</flowPara><flowPara
+         style="line-height:5.4327774px;stroke-width:0.26458332"
+         id="flowPara5450">   3) Then be Druid</flowPara></flowRoot>  </g>
+</svg>


### PR DESCRIPTION
Decided to make the basis for the A2 graph, opening this PR in case of interest.

The Reincarnation Axis has the correct numbers, up until R159, including the amount of gems required, it's probably behind the e308 wall at that point. 

The graph doesnt extend up unti lthe gem required for the past few reincarnations, don't actually know how to fix that, but its kinda funny looking. That part might be deleted if it is beyond the wall anyway.

The suicide part of the graph only extends up to gem requirements for A1, which makes the gap shows the difference between A1 and A2. May bother to fix it up when it gets more content.